### PR TITLE
fix: combine build and publish job

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -16,8 +16,8 @@ on:
       - dev
 
 jobs:
-  build:
-    name: Build Docker Image
+  build-and-publish:
+    name: Build and Publish Docker Image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -27,11 +27,6 @@ jobs:
         run: |
           docker build -t ${{ env.REGISTRY }}/${{ env.ORG }}/${{ env.CONTAINER_NAME }}:${{ env.TAG }} .
 
-  publish:
-    name: Push Docker Image
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,8 +16,8 @@ on:
       - main
 
 jobs:
-  build:
-    name: Build Docker Image
+  build-and-publish:
+    name: Build and Publish Docker Image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -27,11 +27,6 @@ jobs:
         run: |
           docker build -t ${{ env.REGISTRY }}/${{ env.ORG }}/${{ env.CONTAINER_NAME }}:${{ env.TAG }} .
 
-  publish:
-    name: Push Docker Image
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -46,7 +41,7 @@ jobs:
   deploy:
     name: Deploy to VM
     runs-on: ubuntu-latest
-    needs: publish
+    needs: build-and-publish
     steps:
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1.0.3


### PR DESCRIPTION
Each job is a new runner, and does not have access to any artefact from another runner. Therefore, having separate build and publish jobs failed, because the built image was not available to be published.