### PR TITLE
chore: update domain name

### DIFF
--- a/app/pages/artist/[id].tsx
+++ b/app/pages/artist/[id].tsx
@@ -92,7 +92,7 @@ const ArtistDetail = () => {
         <meta property="og:type" content="profile" />
         <meta
           property="og:url"
-          content={`https://bandwidth.melbourne/artist/${artist.artistId || id}`}
+          content={`https://bandwidthmelbourne.com/artist/${artist.artistId || id}`}
         />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
@@ -120,7 +120,7 @@ const ArtistDetail = () => {
         {/* Canonical */}
         <link
           rel="canonical"
-          href={`https://bandwidth.melbourne/artist/${artist.artistId || id}`}
+          href={`https://bandwidthmelbourne.com/artist/${artist.artistId || id}`}
         />
 
         {/* JSON-LD Structured Data */}
@@ -132,7 +132,7 @@ const ArtistDetail = () => {
               "@type": "MusicGroup",
               name: artist.title,
               image: artist.imageUrls?.[0] || "/default-artist.jpg",
-              url: `https://bandwidth.melbourne/artist/${artist.artistId || id}`,
+              url: `https://bandwidthmelbourne.com/artist/${artist.artistId || id}`,
               sameAs: artist.socials || [],
               genre: artist.tags || [],
               foundingLocation: artist.city

--- a/app/pages/artist/index.tsx
+++ b/app/pages/artist/index.tsx
@@ -33,7 +33,7 @@ const Artist = () => {
         />
         <meta property="og:image" content="/default-artist.jpg" />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://bandwidth.melbourne/artist" />
+        <meta property="og:url" content="https://bandwidthmelbourne.com/artist" />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
 
@@ -48,7 +48,7 @@ const Artist = () => {
         <meta name="twitter:site" content="@BandwidthMelb" />
 
         {/* Canonical */}
-        <link rel="canonical" href="https://bandwidth.melbourne/artist" />
+        <link rel="canonical" href="https://bandwidthmelbourne.com/artist" />
 
         {/* JSON-LD Structured Data (CollectionPage of MusicGroup) */}
         <script
@@ -60,11 +60,11 @@ const Artist = () => {
               name: "Melbourne Artists & Bands",
               description:
                 "Browse Melbourne artists and bands across every genre. Discover local talent, explore profiles, and find your next favourite act with Bandwidth.",
-              url: "https://bandwidth.melbourne/artist",
+              url: "https://bandwidthmelbourne.com/artist",
               isPartOf: {
                 "@type": "WebSite",
                 name: "Bandwidth Melbourne Gig Guide",
-                url: "https://bandwidth.melbourne",
+                url: "https://bandwidthmelbourne.com",
               },
               about: {
                 "@type": "MusicGroup",

--- a/app/pages/event/[id].tsx
+++ b/app/pages/event/[id].tsx
@@ -96,7 +96,7 @@ const EventDetail = () => {
         <meta property="og:type" content="event" />
         <meta
           property="og:url"
-          content={`https://bandwidth.melbourne/event/${event.eventId || id}`}
+          content={`https://bandwidthmelbourne.com/event/${event.eventId || id}`}
         />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
@@ -123,7 +123,7 @@ const EventDetail = () => {
         {/* Canonical */}
         <link
           rel="canonical"
-          href={`https://bandwidth.melbourne/event/${event.eventId || id}`}
+          href={`https://bandwidthmelbourne.com/event/${event.eventId || id}`}
         />
 
         {/* JSON-LD Structured Data */}
@@ -163,7 +163,7 @@ const EventDetail = () => {
               organizer: {
                 "@type": "Organization",
                 name: "Bandwidth Melbourne",
-                url: "https://bandwidth.melbourne",
+                url: "https://bandwidthmelbourne.com",
               },
             }),
           }}

--- a/app/pages/event/index.tsx
+++ b/app/pages/event/index.tsx
@@ -72,7 +72,7 @@ const Event = () => {
         />
         <meta property="og:image" content="/default-event.jpg" />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://bandwidth.melbourne/event" />
+        <meta property="og:url" content="https://bandwidthmelbourne.com/event" />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
 
@@ -87,7 +87,7 @@ const Event = () => {
         <meta name="twitter:site" content="@BandwidthMelb" />
 
         {/* Canonical */}
-        <link rel="canonical" href="https://bandwidth.melbourne/event" />
+        <link rel="canonical" href="https://bandwidthmelbourne.com/event" />
 
         {/* JSON-LD Structured Data (CollectionPage of MusicEvents) */}
         <script
@@ -99,11 +99,11 @@ const Event = () => {
               name: "Melbourne Live Music Events",
               description:
                 "Find live music events, concerts, and gigs in Melbourne. Browse upcoming shows by date, venue, and genre — all in one place on Bandwidth.",
-              url: "https://bandwidth.melbourne/event",
+              url: "https://bandwidthmelbourne.com/event",
               isPartOf: {
                 "@type": "WebSite",
                 name: "Bandwidth Melbourne Gig Guide",
-                url: "https://bandwidth.melbourne",
+                url: "https://bandwidthmelbourne.com",
               },
               about: {
                 "@type": "MusicEvent",

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -77,7 +77,7 @@ const Home = () => {
         />
         <meta property="og:image" content="/default-hero.jpg" />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://bandwidth.melbourne" />
+        <meta property="og:url" content="https://bandwidthmelbourne.com" />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
 
@@ -95,7 +95,7 @@ const Home = () => {
         <meta name="twitter:site" content="@BandwidthMelb" />
 
         {/* Canonical */}
-        <link rel="canonical" href="https://bandwidth.melbourne" />
+        <link rel="canonical" href="https://bandwidthmelbourne.com" />
 
         {/* JSON-LD Structured Data */}
         <script
@@ -105,12 +105,12 @@ const Home = () => {
               "@context": "https://schema.org",
               "@type": "WebSite",
               name: "Bandwidth Melbourne Gig Guide",
-              url: "https://bandwidth.melbourne",
+              url: "https://bandwidthmelbourne.com",
               description:
                 "Discover live music in Melbourne with Bandwidth. Explore upcoming gigs, local artists, and venues across the city.",
               potentialAction: {
                 "@type": "SearchAction",
-                target: "https://bandwidth.melbourne/search?q={search_term_string}",
+                target: "https://bandwidthmelbourne.com/search?q={search_term_string}",
                 "query-input": "required name=search_term_string",
               },
             }),

--- a/app/pages/venue/[id].tsx
+++ b/app/pages/venue/[id].tsx
@@ -96,7 +96,7 @@ const VenueDetail = () => {
         <meta property="og:type" content="place" />
         <meta
           property="og:url"
-          content={`https://bandwidth.melbourne/venue/${venue.venueId || id}`}
+          content={`https://bandwidthmelbourne.com/venue/${venue.venueId || id}`}
         />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
@@ -123,7 +123,7 @@ const VenueDetail = () => {
         {/* Canonical */}
         <link
           rel="canonical"
-          href={`https://bandwidth.melbourne/venue/${venue.venueId || id}`}
+          href={`https://bandwidthmelbourne.com/venue/${venue.venueId || id}`}
         />
 
         {/* JSON-LD Structured Data */}
@@ -135,7 +135,7 @@ const VenueDetail = () => {
               "@type": "MusicVenue",
               name: venue.title,
               image: venue.imageUrls?.[0] || "/default-venue.jpg",
-              url: `https://bandwidth.melbourne/venue/${venue.venueId || id}`,
+              url: `https://bandwidthmelbourne.com/venue/${venue.venueId || id}`,
               address: {
                 "@type": "PostalAddress",
                 streetAddress: venue.streetAddress,

--- a/app/pages/venue/index.tsx
+++ b/app/pages/venue/index.tsx
@@ -34,7 +34,7 @@ const Venue = () => {
         />
         <meta property="og:image" content="/default-venue.jpg" />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://bandwidth.melbourne/venue" />
+        <meta property="og:url" content="https://bandwidthmelbourne.com/venue" />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
 
@@ -49,7 +49,7 @@ const Venue = () => {
         <meta name="twitter:site" content="@BandwidthMelb" />
 
         {/* Canonical */}
-        <link rel="canonical" href="https://bandwidth.melbourne/venue" />
+        <link rel="canonical" href="https://bandwidthmelbourne.com/venue" />
 
         {/* JSON-LD Structured Data (CollectionPage of MusicVenues) */}
         <script
@@ -61,11 +61,11 @@ const Venue = () => {
               name: "Melbourne Music Venues",
               description:
                 "Discover the best live music venues in Melbourne. Explore gig locations, bars, clubs, and iconic spaces hosting concerts and events — all on Bandwidth.",
-              url: "https://bandwidth.melbourne/venue",
+              url: "https://bandwidthmelbourne.com/venue",
               isPartOf: {
                 "@type": "WebSite",
                 name: "Bandwidth Melbourne Gig Guide",
-                url: "https://bandwidth.melbourne",
+                url: "https://bandwidthmelbourne.com",
               },
               about: {
                 "@type": "MusicVenue",


### PR DESCRIPTION
Change from `bandwidth.melbourne` to `bandwidthmelbourne.com`.

Change made because .com is a more trusted domain than .melbourne. User testing revealed that some people didn't understand bandwidth.melbourne was a valid url, and would attempt bandwidth.melbourne.com